### PR TITLE
fix missing Content-Type in PATCH or etc.

### DIFF
--- a/AMEURLSession/Classes/AMEURLRequestSerialization.m
+++ b/AMEURLSession/Classes/AMEURLRequestSerialization.m
@@ -26,6 +26,7 @@ static NSString *const kAMECharactersToLeaveUnescapedInQueryStringPairKey = @"[]
         mutableRequest.URL = [NSURL URLWithString:[NSString stringWithFormat:@"%@?%@", [mutableRequest.URL absoluteString], query]];
     } else {
         mutableRequest.HTTPBody = [query dataUsingEncoding:NSUTF8StringEncoding];
+        [mutableRequest setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
     }
 
     return mutableRequest;


### PR DESCRIPTION
POST request defaults to application/x-www-form-urlencoded (in some layer... i don't know where),
but PATCH requests defaults to application/json.

This patch fixes problem that urlencoded PATCH request sent as application/json, by specifying explicit Content-Type header.
